### PR TITLE
feat: Party Popper (3x3 Bomb) power-up

### DIFF
--- a/src/effects/BallEffectManager.ts
+++ b/src/effects/BallEffectManager.ts
@@ -5,6 +5,7 @@ import { BallEffectType } from './BallEffectTypes';
 import { FireballEffectHandler } from './handlers/FireballEffectHandler';
 import { DiscoEffectHandler } from './handlers/DiscoEffectHandler';
 import { ElectricBallEffectHandler } from './handlers/ElectricBallEffectHandler';
+import { BombGlowEffectHandler } from './handlers/BombGlowEffectHandler';
 
 /**
  * Manages multiple simultaneous particle effects on a Ball
@@ -36,6 +37,7 @@ export class BallEffectManager {
       [BallEffectType.FIREBALL, () => new FireballEffectHandler(this.scene)],
       [BallEffectType.DISCO_SPARKLE, () => new DiscoEffectHandler(this.scene)],
       [BallEffectType.ELECTRIC_TRAIL, () => new ElectricBallEffectHandler(this.scene)],
+      [BallEffectType.BOMB_GLOW, () => new BombGlowEffectHandler(this.scene)],
       // Future effects:
       // [BallEffectType.DANGER_SPARKS, () => new DangerSparksHandler(this.scene)],
       // [BallEffectType.BALLOON_TRAIL, () => new BalloonTrailHandler(this.scene)],

--- a/src/effects/BallEffectTypes.ts
+++ b/src/effects/BallEffectTypes.ts
@@ -12,6 +12,7 @@ export enum BallEffectType {
   DISCO_SPARKLE = 'disco_sparkle',
   DANGER_SPARKS = 'danger_sparks',
   ELECTRIC_TRAIL = 'electric_trail',
+  BOMB_GLOW = 'bomb_glow',
   // Future effects:
   // BALLOON_TRAIL = 'balloon_trail',
   // ICE_TRAIL = 'ice_trail',

--- a/src/effects/handlers/BombGlowEffectHandler.ts
+++ b/src/effects/handlers/BombGlowEffectHandler.ts
@@ -1,0 +1,95 @@
+import Phaser from 'phaser';
+import type { Ball } from '../../objects/Ball';
+import { BaseBallEffect } from './BaseBallEffect';
+import { BallEffectType, EffectDepth } from '../BallEffectTypes';
+
+/**
+ * Bomb Glow effect - pulsing orange glow indicating armed Party Popper
+ * Creates a threatening "about to explode" visual:
+ *
+ * 1. Core Glow - Pulsing orange aura around ball
+ * 2. Ember Sparks - Small hot particles drifting off
+ *
+ * Ball pulses with orange-red tint for "armed bomb" feel
+ */
+export class BombGlowEffectHandler extends BaseBallEffect {
+  readonly type = BallEffectType.BOMB_GLOW;
+
+  // Bomb tint cycling colors - orange to red pulse
+  private readonly BALL_TINTS = [
+    0xff4500, // OrangeRed
+    0xff6600, // Dark orange
+    0xff4500, // OrangeRed
+    0xff2200, // Red-orange
+  ];
+
+  private colorIndex: number = 0;
+
+  start(ball: Ball): void {
+    this.ball = ball;
+    this.active = true;
+    this.colorIndex = 0;
+
+    // Apply bomb tint cycling
+    this.applyBombShimmer();
+
+    // Layer 1: Pulsing glow aura
+    this.createGlowAura();
+
+    // Layer 2: Ember sparks
+    this.createEmberSparks();
+
+    // Slow, ominous pulse - feels like a ticking bomb
+    this.applyPulseTween(0.9, 1.15, 400);
+  }
+
+  private applyBombShimmer(): void {
+    if (!this.ball) return;
+
+    // Moderate shimmer for armed-bomb feel
+    this.colorCycleEvent = this.scene.time.addEvent({
+      delay: 150,
+      callback: () => {
+        if (this.ball && this.active) {
+          this.setEffectTint(this.BALL_TINTS[this.colorIndex]);
+          this.colorIndex = (this.colorIndex + 1) % this.BALL_TINTS.length;
+        }
+      },
+      loop: true,
+    });
+  }
+
+  private createGlowAura(): void {
+    // Soft pulsing orange glow behind the ball
+    this.createEmitter('particle-flame', EffectDepth.SMOKE, {
+      speed: { min: 10, max: 30 },
+      scale: { start: 1.8, end: 0.3 },
+      alpha: { start: 0.5, end: 0 },
+      lifespan: 300,
+      frequency: 40,
+      quantity: 2,
+      tint: [0xff4500, 0xff6600, 0xff2200],
+      blendMode: Phaser.BlendModes.ADD,
+      angle: { min: 0, max: 360 },
+    });
+  }
+
+  private createEmberSparks(): void {
+    // Small hot ember particles drifting away
+    this.createEmitter('particle-spark', EffectDepth.SPARKLE, {
+      speed: { min: 30, max: 80 },
+      scale: { start: 0.6, end: 0 },
+      alpha: { start: 1, end: 0 },
+      lifespan: { min: 200, max: 400 },
+      frequency: 80,
+      quantity: 1,
+      tint: [0xff4500, 0xffaa00, 0xffcc00],
+      blendMode: Phaser.BlendModes.ADD,
+      angle: { min: 0, max: 360 },
+    });
+  }
+
+  stop(): void {
+    super.stop();
+  }
+}

--- a/src/objects/Ball.ts
+++ b/src/objects/Ball.ts
@@ -17,6 +17,9 @@ export class Ball extends Phaser.Physics.Arcade.Sprite {
   private isElectricBall: boolean = false; // Electric Ball power-up
   private attachedPaddle: Paddle | null = null;
 
+  // Party Popper bomb state (one-shot)
+  private bomb: boolean = false;
+
   // FireBall power-up state (gameplay logic)
   private fireball: boolean = false;
   private fireballLevel: number = 0;
@@ -200,6 +203,29 @@ export class Ball extends Phaser.Physics.Arcade.Sprite {
   }
 
   /**
+   * Set bomb mode (Party Popper power-up - one-shot 3x3 explosion)
+   */
+  setBomb(): void {
+    this.bomb = true;
+    this.effectManager?.applyEffect(BallEffectType.BOMB_GLOW);
+  }
+
+  /**
+   * Clear bomb mode (after detonation)
+   */
+  clearBomb(): void {
+    this.bomb = false;
+    this.effectManager?.removeEffect(BallEffectType.BOMB_GLOW);
+  }
+
+  /**
+   * Check if bomb mode is active
+   */
+  hasBomb(): boolean {
+    return this.bomb;
+  }
+
+  /**
    * Set ball speed (for level progression)
    */
   setSpeed(speed: number): void {
@@ -238,6 +264,7 @@ export class Ball extends Phaser.Physics.Arcade.Sprite {
     this.attachedPaddle = null;
     this.fireball = false;
     this.fireballLevel = 0;
+    this.bomb = false;
     this.pendingVelocityRestore = false;
 
     // Clear all visual effects

--- a/src/objects/SafetyNet.ts
+++ b/src/objects/SafetyNet.ts
@@ -1,0 +1,146 @@
+import Phaser from 'phaser';
+import {
+  PLAYABLE_WIDTH,
+  PLAY_AREA_Y,
+  PLAYABLE_HEIGHT,
+  AUDIO,
+} from '../config/Constants';
+import { AudioManager } from '../systems/AudioManager';
+
+/**
+ * SafetyNet — a one-use horizontal bar that sits just above the death zone.
+ * When a ball hits it, the ball bounces upward and the net is consumed (pop animation).
+ */
+export class SafetyNet extends Phaser.Physics.Arcade.Sprite {
+  private consumed: boolean = false;
+  private glowTween: Phaser.Tweens.Tween | null = null;
+
+  /** Y position: just above the death zone, below the paddle */
+  static readonly NET_Y = PLAY_AREA_Y + PLAYABLE_HEIGHT - 10;
+  static readonly NET_WIDTH = PLAYABLE_WIDTH - 40; // Slightly narrower than play area
+  static readonly NET_HEIGHT = 8;
+
+  constructor(scene: Phaser.Scene) {
+    super(scene, PLAYABLE_WIDTH / 2, SafetyNet.NET_Y, 'safety-net');
+
+    scene.add.existing(this);
+    scene.physics.add.existing(this, false); // dynamic body so collider works
+
+    // Configure physics — immovable so ball bounces off it
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.setImmovable(true);
+    body.setAllowGravity(false);
+    body.moves = false;
+
+    // Set collision body size to match the texture
+    body.setSize(SafetyNet.NET_WIDTH, SafetyNet.NET_HEIGHT);
+
+    // Visual: slightly transparent, green glow
+    this.setAlpha(0.8);
+    this.setDepth(5);
+
+    // Spawn animation: inflate from nothing
+    this.setScale(0, 0.5);
+    scene.tweens.add({
+      targets: this,
+      scaleX: 1,
+      scaleY: 1,
+      duration: 300,
+      ease: 'Back.easeOut',
+    });
+
+    // Pulsing glow effect
+    this.glowTween = scene.tweens.add({
+      targets: this,
+      alpha: { from: 0.6, to: 1 },
+      duration: 800,
+      yoyo: true,
+      repeat: -1,
+      ease: 'Sine.easeInOut',
+    });
+  }
+
+  /**
+   * Whether this net has already been consumed
+   */
+  isConsumed(): boolean {
+    return this.consumed;
+  }
+
+  /**
+   * Called when a ball hits the net — bounce the ball and destroy the net
+   */
+  onBallHit(ball: Phaser.Physics.Arcade.Sprite): void {
+    if (this.consumed) return;
+    this.consumed = true;
+
+    // Bounce the ball upward
+    const ballBody = ball.body as Phaser.Physics.Arcade.Body;
+    // Ensure ball moves upward with a strong bounce
+    const speed = Math.max(Math.abs(ballBody.velocity.y), 300);
+    ballBody.velocity.y = -speed;
+
+    // Ensure the ball is above the net after bounce
+    ball.y = this.y - SafetyNet.NET_HEIGHT / 2 - 12;
+
+    // Play bounce SFX
+    AudioManager.getInstance().playSFX(AUDIO.SFX.BOUNCE);
+
+    // Stop glow
+    if (this.glowTween) {
+      this.glowTween.stop();
+      this.glowTween = null;
+    }
+
+    // Disable physics immediately so no further collisions
+    (this.body as Phaser.Physics.Arcade.Body).enable = false;
+
+    // Pop animation: expand and fade out
+    this.scene.tweens.add({
+      targets: this,
+      scaleX: 1.3,
+      scaleY: 2.5,
+      alpha: 0,
+      duration: 250,
+      ease: 'Quad.easeOut',
+      onComplete: () => {
+        this.destroy();
+      },
+    });
+
+    // Spawn pop particles
+    this.spawnPopParticles();
+  }
+
+  /**
+   * Pop particle burst when the net is consumed
+   */
+  private spawnPopParticles(): void {
+    const particles = this.scene.add.particles(this.x, this.y, 'particle-sparkle', {
+      speed: { min: 50, max: 200 },
+      angle: { min: 0, max: 360 },
+      scale: { start: 1, end: 0 },
+      alpha: { start: 1, end: 0 },
+      lifespan: 500,
+      quantity: 20,
+      tint: [0x90ee90, 0x00ff00, 0xffffff],
+      emitting: false,
+    });
+    particles.explode();
+
+    this.scene.time.delayedCall(600, () => {
+      particles.destroy();
+    });
+  }
+
+  /**
+   * Clean up tweens on destroy
+   */
+  destroy(fromScene?: boolean): void {
+    if (this.glowTween) {
+      this.glowTween.stop();
+      this.glowTween = null;
+    }
+    super.destroy(fromScene);
+  }
+}

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -88,6 +88,9 @@ export class BootScene extends Phaser.Scene {
     // Create power-up textures
     this.createPowerUpTextures();
 
+    // Create safety net texture
+    this.createSafetyNetTexture();
+
     // Create particle textures
     this.createParticleTextures();
   }
@@ -138,6 +141,9 @@ export class BootScene extends Phaser.Scene {
       { name: 'powerball', color: POWERUP_CONFIGS[PowerUpType.POWERBALL].color, symbol: 'P' },
       { name: 'fireball', color: POWERUP_CONFIGS[PowerUpType.FIREBALL].color, symbol: 'F' },
       { name: 'electricball', color: POWERUP_CONFIGS[PowerUpType.ELECTRICBALL].color, symbol: 'Z' },
+      { name: 'bouncehouse', color: POWERUP_CONFIGS[PowerUpType.BOUNCE_HOUSE].color, symbol: 'N' },
+      { name: 'bassdrop', color: POWERUP_CONFIGS[PowerUpType.BASS_DROP].color, symbol: '♪' },
+      { name: 'partypopper', color: POWERUP_CONFIGS[PowerUpType.PARTY_POPPER].color, symbol: 'X' },
     ];
 
     const size = 24;
@@ -156,6 +162,29 @@ export class BootScene extends Phaser.Scene {
       g.generateTexture(`powerup-${name}`, size, size);
       g.destroy();
     });
+  }
+
+  private createSafetyNetTexture(): void {
+    // Import SafetyNet dimensions
+    const width = 760;  // PLAYABLE_WIDTH - 40
+    const height = 8;
+
+    const g = this.make.graphics({ x: 0, y: 0 });
+
+    // Main bar — bright green with slight gradient feel
+    g.fillStyle(0x90ee90, 0.9);
+    g.fillRoundedRect(0, 0, width, height, 3);
+
+    // Inner glow line
+    g.fillStyle(0x00ff00, 0.6);
+    g.fillRoundedRect(2, 2, width - 4, height - 4, 2);
+
+    // Border
+    g.lineStyle(1, 0xffffff, 0.5);
+    g.strokeRoundedRect(0, 0, width, height, 3);
+
+    g.generateTexture('safety-net', width, height);
+    g.destroy();
   }
 
   private createParticleTextures(): void {

--- a/src/systems/PowerUpFeedbackSystem.ts
+++ b/src/systems/PowerUpFeedbackSystem.ts
@@ -112,6 +112,41 @@ const POWERUP_FEEDBACK_CONFIG: Record<PowerUpType, PowerUpFeedbackConfig> = {
       flash: { duration: 120, color: POWERUP_CONFIGS[PowerUpType.ELECTRICBALL].color, alpha: 0.45 },
     },
   },
+  [PowerUpType.PARTY_POPPER]: {
+    displayName: '💣 PARTY POPPER!',
+    color: POWERUP_CONFIGS[PowerUpType.PARTY_POPPER].color,
+    particles: {
+      colors: [0xff4500, 0xff6600, 0xffaa00, 0xffcc00, 0xffffff],
+      count: 15,
+    },
+    screenEffect: {
+      flash: { duration: 150, color: POWERUP_CONFIGS[PowerUpType.PARTY_POPPER].color, alpha: 0.5 },
+      shake: { duration: 100, intensity: 0.005 },
+    },
+  },
+  [PowerUpType.BOUNCE_HOUSE]: {
+    displayName: 'BOUNCE HOUSE!',
+    color: POWERUP_CONFIGS[PowerUpType.BOUNCE_HOUSE].color,
+    particles: {
+      colors: [0x90ee90, 0xffffff, 0x66ff66],
+      count: 10,
+    },
+    screenEffect: {
+      flash: { duration: 100, color: POWERUP_CONFIGS[PowerUpType.BOUNCE_HOUSE].color, alpha: 0.3 },
+    },
+  },
+  [PowerUpType.BASS_DROP]: {
+    displayName: '🎵 BASS DROP! 🎵',
+    color: POWERUP_CONFIGS[PowerUpType.BASS_DROP].color,
+    particles: {
+      colors: [0x9400d3, 0xba55d3, 0xff00ff, 0x8b008b, 0xffffff],
+      count: 25,
+    },
+    screenEffect: {
+      flash: { duration: 300, color: 0x9400d3, alpha: 0.7 },
+      shake: { duration: 500, intensity: 0.02 },
+    },
+  },
 };
 
 /**

--- a/src/types/PowerUpTypes.ts
+++ b/src/types/PowerUpTypes.ts
@@ -10,6 +10,9 @@ export enum PowerUpType {
   POWERBALL = 'powerball', // Double power-up drop chance (12s)
   FIREBALL = 'fireball', // Piercing ball with stacking damage (10s)
   ELECTRICBALL = 'electricball', // Electric ball with AOE damage (8s)
+  PARTY_POPPER = 'partypopper', // 3x3 bomb explosion on next brick hit (one-shot)
+  BOUNCE_HOUSE = 'bouncehouse', // Safety net that saves ball once (until used)
+  BASS_DROP = 'bassdrop',       // Instant 1 damage to ALL bricks on screen
 }
 
 /**
@@ -82,6 +85,27 @@ export const POWERUP_CONFIGS: Record<PowerUpType, PowerUpConfig> = {
     duration: 8000,       // 8 seconds
     dropWeight: 12,
     emoji: '⚡',
+  },
+  [PowerUpType.PARTY_POPPER]: {
+    type: PowerUpType.PARTY_POPPER,
+    color: 0xff4500,      // OrangeRed
+    duration: 0,          // Until used (one-shot)
+    dropWeight: 10,
+    emoji: '💣',
+  },
+  [PowerUpType.BOUNCE_HOUSE]: {
+    type: PowerUpType.BOUNCE_HOUSE,
+    color: 0x90ee90,      // Light green
+    duration: 0,          // Until used (one-shot)
+    dropWeight: 10,
+    emoji: '🛡️',
+  },
+  [PowerUpType.BASS_DROP]: {
+    type: PowerUpType.BASS_DROP,
+    color: 0x9400d3,      // Dark violet
+    duration: 0,          // Instant effect
+    dropWeight: 8,
+    emoji: '🎵',
   },
 };
 


### PR DESCRIPTION
## Party Popper Power-Up 💣

Implements the **Party Popper** — a one-shot 3×3 bomb power-up. When collected, the ball is armed with a bomb. On the next brick hit, all bricks in a 3×3 grid around the hit brick take 1 damage with an explosion effect. The bomb is then consumed.

### What changed

| File | Change |
|------|--------|
| `src/types/PowerUpTypes.ts` | `PARTY_POPPER` enum + config (color `0xff4500`, duration `0`, dropWeight `10`, emoji `💣`) |
| `src/objects/Ball.ts` | `bomb` state with `setBomb()` / `clearBomb()` / `hasBomb()` methods |
| `src/effects/BallEffectTypes.ts` | `BOMB_GLOW` effect type |
| `src/effects/handlers/BombGlowEffectHandler.ts` | **New** — pulsing orange glow aura + ember spark particles |
| `src/effects/BallEffectManager.ts` | Register `BOMB_GLOW` handler |
| `src/systems/PowerUpSystem.ts` | `applyPartyPopper()` handler + propagation config for multi-ball |
| `src/systems/CollisionHandler.ts` | 3×3 explosion logic: `processBombExplosion()`, `findBricksInRadius()`, `worldToGrid()`, explosion particles, `setBricks()` |
| `src/scenes/GameScene.ts` | Wire `collisionHandler.setBricks()` call |
| `src/scenes/BootScene.ts` | `partypopper` texture entry |
| `src/systems/PowerUpFeedbackSystem.ts` | Feedback config (💣 PARTY POPPER! popup, orange particles, flash + shake) |

### How it works

1. **Collect** the Party Popper → ball gets pulsing orange glow (BOMB_GLOW visual)
2. **Hit any brick** → `handleBallBrick` detects `hasBomb()`, calls `processBombExplosion()`
3. **3×3 grid search** → `findBricksInRadius(source, 1)` converts world→grid coords and finds all bricks within ±1 grid cell
4. **Damage cascade** → each adjacent brick takes 1 damage (with 50ms stagger), scores 75% value, rolls for power-up drops
5. **Explosion VFX** → orange/white flame particles at source + each damaged brick, strong screen shake (200ms, 0.01 intensity)
6. **Consumed** → `clearBomb()` removes bomb state and BOMB_GLOW visual

### Test instructions

```js
GameDebug.spawnPowerUp('partypopper', 400, 300)
```

- Collect it → verify ball has pulsing orange glow indicator
- Hit a brick in middle of formation → verify 3×3 area takes damage
- Verify bomb is consumed (single use, glow disappears after detonation)
- Verify explosion particles + screen shake on detonation
- Test with multi-ball (Disco) — all balls should get bomb, each detonates independently