### PR TITLE
refactor: Migrate DANGER_SPARKS and BALLOON_TRAIL to proper BallEffect handlers

### DIFF
--- a/src/effects/BallEffectManager.ts
+++ b/src/effects/BallEffectManager.ts
@@ -5,6 +5,8 @@ import { BallEffectType } from './BallEffectTypes';
 import { FireballEffectHandler } from './handlers/FireballEffectHandler';
 import { DiscoEffectHandler } from './handlers/DiscoEffectHandler';
 import { ElectricBallEffectHandler } from './handlers/ElectricBallEffectHandler';
+import { DangerSparksEffectHandler } from './handlers/DangerSparksEffectHandler';
+import { BalloonTrailEffectHandler } from './handlers/BalloonTrailEffectHandler';
 
 /**
  * Manages multiple simultaneous particle effects on a Ball
@@ -36,9 +38,8 @@ export class BallEffectManager {
       [BallEffectType.FIREBALL, () => new FireballEffectHandler(this.scene)],
       [BallEffectType.DISCO_SPARKLE, () => new DiscoEffectHandler(this.scene)],
       [BallEffectType.ELECTRIC_TRAIL, () => new ElectricBallEffectHandler(this.scene)],
-      // Future effects:
-      // [BallEffectType.DANGER_SPARKS, () => new DangerSparksHandler(this.scene)],
-      // [BallEffectType.BALLOON_TRAIL, () => new BalloonTrailHandler(this.scene)],
+      [BallEffectType.DANGER_SPARKS, () => new DangerSparksEffectHandler(this.scene)],
+      [BallEffectType.BALLOON_TRAIL, () => new BalloonTrailEffectHandler(this.scene)],
     ]);
   }
 

--- a/src/effects/BallEffectTypes.ts
+++ b/src/effects/BallEffectTypes.ts
@@ -12,8 +12,8 @@ export enum BallEffectType {
   DISCO_SPARKLE = 'disco_sparkle',
   DANGER_SPARKS = 'danger_sparks',
   ELECTRIC_TRAIL = 'electric_trail',
+  BALLOON_TRAIL = 'balloon_trail',
   // Future effects:
-  // BALLOON_TRAIL = 'balloon_trail',
   // ICE_TRAIL = 'ice_trail',
 }
 

--- a/src/effects/handlers/BalloonTrailEffectHandler.ts
+++ b/src/effects/handlers/BalloonTrailEffectHandler.ts
@@ -1,0 +1,37 @@
+import Phaser from 'phaser';
+import type { Ball } from '../../objects/Ball';
+import { BaseBallEffect } from './BaseBallEffect';
+import { BallEffectType, EffectDepth } from '../BallEffectTypes';
+
+/**
+ * Balloon trail effect handler — subtle light blue bubble trail
+ * Active during the Balloon (slow-ball) power-up
+ */
+export class BalloonTrailEffectHandler extends BaseBallEffect {
+  readonly type = BallEffectType.BALLOON_TRAIL;
+
+  start(ball: Ball): void {
+    this.ball = ball;
+    this.active = true;
+
+    // Gentle bubble/glow trail behind the ball
+    this.createEmitter('particle-glow', EffectDepth.TRAIL, {
+      speed: { min: 5, max: 20 },
+      scale: { start: 0.4, end: 0 },
+      alpha: { start: 0.6, end: 0 },
+      lifespan: 450,
+      frequency: 70,
+      quantity: 1,
+      tint: [0x87CEEB, 0xADD8E6, 0xE0F7FF, 0xFFFFFF],
+      blendMode: Phaser.BlendModes.ADD,
+      angle: { min: 250, max: 290 }, // Upward float direction
+    });
+
+    // Subtle light blue tint on the ball
+    this.setEffectTint(0xAADDFF);
+  }
+
+  stop(): void {
+    super.stop();
+  }
+}

--- a/src/effects/handlers/DangerSparksEffectHandler.ts
+++ b/src/effects/handlers/DangerSparksEffectHandler.ts
@@ -1,0 +1,36 @@
+import Phaser from 'phaser';
+import type { Ball } from '../../objects/Ball';
+import { BaseBallEffect } from './BaseBallEffect';
+import { BallEffectType, EffectDepth } from '../BallEffectTypes';
+
+/**
+ * Danger spark effect handler — red/orange sparks on last life
+ * Migrated from ParticleSystem.dangerSparks() into the effect handler system
+ */
+export class DangerSparksEffectHandler extends BaseBallEffect {
+  readonly type = BallEffectType.DANGER_SPARKS;
+
+  start(ball: Ball): void {
+    this.ball = ball;
+    this.active = true;
+
+    // Red/orange spark emitter above the ball
+    this.createEmitter('particle-spark', EffectDepth.SPARKLE, {
+      speed: { min: 20, max: 50 },
+      scale: { start: 0.8, end: 0 },
+      alpha: { start: 0.8, end: 0 },
+      lifespan: 300,
+      frequency: 50,
+      quantity: 1,
+      tint: [0xff6b6b, 0xff0000, 0xffaa00],
+      blendMode: Phaser.BlendModes.ADD,
+    });
+
+    // Subtle red tint on the ball
+    this.setEffectTint(0xff4444);
+  }
+
+  stop(): void {
+    super.stop();
+  }
+}

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -46,7 +46,6 @@ export class GameScene extends Phaser.Scene {
   private powerUpFeedbackSystem!: PowerUpFeedbackSystem;
   private collisionHandler!: CollisionHandler;
   private electricArcSystem!: ElectricArcSystem;
-  private dangerSparkEmitters: Phaser.GameObjects.Particles.ParticleEmitter[] = [];
   private isInDanger: boolean = false;
 
   // Audio
@@ -650,8 +649,7 @@ export class GameScene extends Phaser.Scene {
 
     // Add spark trail to all active balls
     this.ballPool.getActiveBalls().forEach((ball) => {
-      const sparks = this.particleSystem.dangerSparks(ball);
-      if (sparks) this.dangerSparkEmitters.push(sparks);
+      ball.applyEffect(BallEffectType.DANGER_SPARKS);
     });
 
     // Enable slow-motion briefly when entering danger
@@ -669,11 +667,10 @@ export class GameScene extends Phaser.Scene {
     // Hide danger indicator
     this.screenEffects.hideDangerIndicator();
 
-    // Stop all danger spark emitters
-    this.dangerSparkEmitters.forEach((emitter) => {
-      this.particleSystem.stopDangerSparks(emitter);
+    // Stop all danger spark effects
+    this.ballPool.getActiveBalls().forEach((ball) => {
+      ball.removeEffect(BallEffectType.DANGER_SPARKS);
     });
-    this.dangerSparkEmitters = [];
 
     // Ensure slow motion is disabled
     this.screenEffects.disableSlowMotion();

--- a/src/systems/ParticleSystem.ts
+++ b/src/systems/ParticleSystem.ts
@@ -2,11 +2,12 @@ import Phaser from 'phaser';
 import { COLORS } from '../config/Constants';
 
 /**
- * Manages all particle effects in the game:
+ * Manages scene-level particle effects:
  * - Confetti burst on brick destruction
  * - Streamers on level clear
- * - Danger sparks on last life
- * - Fireball trails
+ *
+ * Ball-level effects (danger sparks, fireball trails, etc.) are handled
+ * by the BallEffectManager / BaseBallEffect handler system.
  */
 export class ParticleSystem {
   private scene: Phaser.Scene;
@@ -81,140 +82,4 @@ export class ParticleSystem {
     }
   }
 
-  /**
-   * Danger warning particles when on last ball
-   */
-  dangerSparks(ball: Phaser.GameObjects.Sprite): Phaser.GameObjects.Particles.ParticleEmitter | null {
-    if (!ball || !ball.active) return null;
-
-    const particles = this.scene.add.particles(0, 0, 'particle-spark', {
-      follow: ball,
-      speed: { min: 20, max: 50 },
-      scale: { start: 0.8, end: 0 },
-      alpha: { start: 0.8, end: 0 },
-      lifespan: 300,
-      frequency: 50,
-      quantity: 1,
-      tint: [0xff6b6b, 0xff0000, 0xffaa00],
-      blendMode: Phaser.BlendModes.ADD,
-    });
-
-    return particles;
-  }
-
-  /**
-   * Stop danger sparks
-   */
-  stopDangerSparks(emitter: Phaser.GameObjects.Particles.ParticleEmitter | null): void {
-    if (emitter) {
-      emitter.stop();
-      this.scene.time.delayedCall(400, () => {
-        emitter.destroy();
-      });
-    }
-  }
-
-  /**
-   * Start fireball trail effect - returns emitter for cleanup
-   * Visual intensity caps at level 3
-   */
-  startFireballTrail(ball: Phaser.GameObjects.Sprite, level: number): Phaser.GameObjects.Particles.ParticleEmitter {
-    const effectiveLevel = Math.min(level, 3) as 1 | 2 | 3;
-
-    const configs: Record<1 | 2 | 3, {
-      colors: number[];
-      quantity: number;
-      frequency: number;
-      lifespan: number;
-      scale: { start: number; end: number };
-    }> = {
-      1: {
-        colors: [0xff4500, 0xff6600],
-        quantity: 1,
-        frequency: 40,
-        lifespan: 200,
-        scale: { start: 0.6, end: 0 },
-      },
-      2: {
-        colors: [0xff4500, 0xff8800, 0xffcc00, 0xffffff],
-        quantity: 2,
-        frequency: 30,
-        lifespan: 350,
-        scale: { start: 0.9, end: 0 },
-      },
-      3: {
-        colors: [0xffffff, 0xffff00, 0xff8800, 0xff4500, 0xff2200],
-        quantity: 3,
-        frequency: 20,
-        lifespan: 500,
-        scale: { start: 1.2, end: 0 },
-      },
-    };
-
-    const config = configs[effectiveLevel];
-
-    const emitter = this.scene.add.particles(0, 0, 'particle-flame', {
-      follow: ball,
-      speed: { min: 10, max: 30 },
-      scale: config.scale,
-      alpha: { start: 0.9, end: 0 },
-      lifespan: config.lifespan,
-      frequency: config.frequency,
-      quantity: config.quantity,
-      tint: config.colors,
-      blendMode: Phaser.BlendModes.ADD,
-      angle: { min: 0, max: 360 },
-    });
-
-    return emitter;
-  }
-
-  /**
-   * Update fireball trail intensity (when level changes)
-   */
-  updateFireballTrail(emitter: Phaser.GameObjects.Particles.ParticleEmitter, level: number): void {
-    const effectiveLevel = Math.min(level, 3) as 1 | 2 | 3;
-
-    const configs: Record<1 | 2 | 3, { frequency: number; lifespan: number; quantity: number }> = {
-      1: { frequency: 40, lifespan: 200, quantity: 1 },
-      2: { frequency: 30, lifespan: 350, quantity: 2 },
-      3: { frequency: 20, lifespan: 500, quantity: 3 },
-    };
-
-    const config = configs[effectiveLevel];
-    emitter.frequency = config.frequency;
-    // Update emitter properties directly
-    (emitter as unknown as { lifespan: { propertyValue: number } }).lifespan.propertyValue = config.lifespan;
-    (emitter as unknown as { quantity: { propertyValue: number } }).quantity.propertyValue = config.quantity;
-  }
-
-  /**
-   * Stop fireball trail with fadeout
-   */
-  stopFireballTrail(emitter: Phaser.GameObjects.Particles.ParticleEmitter | null): void {
-    if (emitter) {
-      emitter.stop();
-      this.scene.time.delayedCall(600, () => {
-        emitter.destroy();
-      });
-    }
-  }
-
-  /**
-   * Start smoke trail (level 3 only) - darker particles behind the flames
-   */
-  startSmokeTrail(ball: Phaser.GameObjects.Sprite): Phaser.GameObjects.Particles.ParticleEmitter {
-    return this.scene.add.particles(0, 0, 'particle-spark', {
-      follow: ball,
-      followOffset: { x: 0, y: 2 },
-      speed: { min: 5, max: 15 },
-      scale: { start: 0.8, end: 0 },
-      alpha: { start: 0.4, end: 0 },
-      lifespan: 400,
-      frequency: 50,
-      quantity: 1,
-      tint: [0x442200, 0x331100, 0x220000],
-      blendMode: Phaser.BlendModes.NORMAL,
-    });
-  }
 }

--- a/src/systems/PowerUpSystem.ts
+++ b/src/systems/PowerUpSystem.ts
@@ -201,6 +201,7 @@ export class PowerUpSystem {
     const remaining = Math.max(0, this.balloonEndTime - this.scene.time.now);
     if (remaining > 0) {
       ball.setFloating(remaining);
+      ball.applyEffect(BallEffectType.BALLOON_TRAIL);
     }
   }
 
@@ -212,6 +213,12 @@ export class PowerUpSystem {
     this.balloonTimer = null;
     // Ball.setFloating already handles its own timer reset via scene.time.delayedCall
     // so we don't need to explicitly clear floating state here
+
+    // Remove balloon trail from all active balls
+    this.ballPool.getActiveBalls().forEach((ball) => {
+      ball.removeEffect(BallEffectType.BALLOON_TRAIL);
+    });
+
     this.events.emit('effectExpired', PowerUpType.BALLOON);
   }
 


### PR DESCRIPTION
## Summary
Migrates danger spark particles from ParticleSystem into a proper `DangerSparksEffectHandler`, and implements a new `BalloonTrailEffectHandler` with a subtle bubble trail visual for the Balloon slow-ball power-up.

Both effects now follow the established handler pattern (BaseBallEffect → BallEffectManager registry), supporting tint blending, depth layering, and proper lifecycle management.

Closes #15

## Changes
- **New**: `DangerSparksEffectHandler` — red/orange spark trail on last life
- **New**: `BalloonTrailEffectHandler` — light blue bubble trail during Balloon power-up
- **Refactored**: GameScene uses `ball.applyEffect()`/`removeEffect()` instead of manual ParticleSystem calls
- **Cleaned up**: Removed dead danger spark and fireball methods from ParticleSystem
- **Updated**: PowerUpSystem applies/removes BALLOON_TRAIL effect with Balloon power-up lifecycle

## Test Instructions
1. Build passes clean
2. Play until last life — danger sparks should appear on ball (red/orange sparks, same visual as before)
3. Gain a life back or reset — sparks should stop
4. Collect a Balloon power-up — ball should slow down AND show a subtle light blue bubble trail
5. Wait for Balloon to expire — trail should fade out
6. Test Balloon + Fireball combo — both effects should layer correctly with blended tint
7. Test Balloon + Disco (multi-ball) — new balls should NOT get the balloon trail (balloon doesnt propagate)