### PR TITLE
fix: Remove powerUpDropChance from level data tests

### DIFF
--- a/src/__tests__/levelData.test.ts
+++ b/src/__tests__/levelData.test.ts
@@ -24,16 +24,10 @@ describe('Level Data', () => {
         expect(level.ballSpeedMultiplier).toBeDefined();
         expect(level.backgroundColor).toBeDefined();
         expect(level.bricks).toBeDefined();
-        expect(level.powerUpDropChance).toBeDefined();
       });
 
       it('should have a positive ballSpeedMultiplier', () => {
         expect(level.ballSpeedMultiplier).toBeGreaterThan(0);
-      });
-
-      it('should have powerUpDropChance between 0 and 1', () => {
-        expect(level.powerUpDropChance).toBeGreaterThanOrEqual(0);
-        expect(level.powerUpDropChance).toBeLessThanOrEqual(1);
       });
 
       it('should have bricks with valid types', () => {


### PR DESCRIPTION
## Summary
Removes the `powerUpDropChance` test assertions from `levelData.test.ts` since the field was removed from `LevelData` in PR #20.

The CI tests were introduced in PR #23 while PR #20 was still open, so the tests referenced the field that PR #20 subsequently removed.

Closes #14

## Changes
- Removed `powerUpDropChance` field existence check from level validation
- Removed `powerUpDropChance` range test (0-1)
- Tests: 126 pass (was 136, 10 removed as invalid + 10 fewer duplicate assertions)

## Test Instructions
1. `npm test` — 126 tests pass, zero failures
2. `npm run build` — builds clean