### PR TITLE
feat: Party Favor power-up (extra life)

### DIFF
--- a/docs/PLAN-powerups-v2.md
+++ b/docs/PLAN-powerups-v2.md
@@ -29,9 +29,9 @@ Add 5 new power-ups to Geno's Block Party. Each feature is implemented in its ow
 ## Features
 
 ### 1. 🎁 Party Favor (Extra Life)
-**Status**: `TODO`  
+**Status**: `IN_PROGRESS`  
 **Branch**: `feature/powerup-party-favor`  
-**PR**: —
+**PR**: https://github.com/genobear/Genos-Block-Party/pull/1
 
 **Description**: Drops a bonus life (+1). Rare but clutch.
 

--- a/src/__tests__/levelData.test.ts
+++ b/src/__tests__/levelData.test.ts
@@ -24,16 +24,10 @@ describe('Level Data', () => {
         expect(level.ballSpeedMultiplier).toBeDefined();
         expect(level.backgroundColor).toBeDefined();
         expect(level.bricks).toBeDefined();
-        expect(level.powerUpDropChance).toBeDefined();
       });
 
       it('should have a positive ballSpeedMultiplier', () => {
         expect(level.ballSpeedMultiplier).toBeGreaterThan(0);
-      });
-
-      it('should have powerUpDropChance between 0 and 1', () => {
-        expect(level.powerUpDropChance).toBeGreaterThanOrEqual(0);
-        expect(level.powerUpDropChance).toBeLessThanOrEqual(1);
       });
 
       it('should have bricks with valid types', () => {

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -138,6 +138,7 @@ export class BootScene extends Phaser.Scene {
       { name: 'powerball', color: POWERUP_CONFIGS[PowerUpType.POWERBALL].color, symbol: 'P' },
       { name: 'fireball', color: POWERUP_CONFIGS[PowerUpType.FIREBALL].color, symbol: 'F' },
       { name: 'electricball', color: POWERUP_CONFIGS[PowerUpType.ELECTRICBALL].color, symbol: 'Z' },
+      { name: 'partyfavor', color: POWERUP_CONFIGS[PowerUpType.PARTY_FAVOR].color, symbol: '+' },
     ];
 
     const size = 24;

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -193,6 +193,12 @@ export class GameScene extends Phaser.Scene {
       this.powerUpFeedbackSystem.revealMystery(actualType);
     });
 
+    // Handle extra life from Party Favor power-up
+    this.powerUpSystem.events.on('grantExtraLife', () => {
+      this.lives++;
+      this.events.emit('livesUpdate', this.lives);
+    });
+
     // Emit initial state to UI
     this.events.emit('scoreUpdate', this.score);
     this.events.emit('livesUpdate', this.lives);
@@ -222,6 +228,7 @@ export class GameScene extends Phaser.Scene {
     this.powerUpSystem?.events?.off('effectApplied');
     this.powerUpSystem?.events?.off('effectExpired');
     this.powerUpSystem?.events?.off('mysteryRevealed');
+    this.powerUpSystem?.events?.off('grantExtraLife');
 
     // Clean up input events
     this.input?.off('pointerdown', this.handleClick, this);

--- a/src/systems/PowerUpFeedbackSystem.ts
+++ b/src/systems/PowerUpFeedbackSystem.ts
@@ -112,6 +112,17 @@ const POWERUP_FEEDBACK_CONFIG: Record<PowerUpType, PowerUpFeedbackConfig> = {
       flash: { duration: 120, color: POWERUP_CONFIGS[PowerUpType.ELECTRICBALL].color, alpha: 0.45 },
     },
   },
+  [PowerUpType.PARTY_FAVOR]: {
+    displayName: 'EXTRA LIFE!',
+    color: POWERUP_CONFIGS[PowerUpType.PARTY_FAVOR].color,
+    particles: {
+      colors: [0xff69b4, 0xffd700, 0xffffff, 0xff1493],
+      count: 20,
+    },
+    screenEffect: {
+      flash: { duration: 200, color: 0xffd700, alpha: 0.5 },
+    },
+  },
 };
 
 /**

--- a/src/systems/PowerUpSystem.ts
+++ b/src/systems/PowerUpSystem.ts
@@ -92,6 +92,7 @@ export class PowerUpSystem {
       [PowerUpType.POWERBALL, () => this.applyPowerBall()],
       [PowerUpType.FIREBALL, () => this.applyFireball()],
       [PowerUpType.ELECTRICBALL, () => this.applyElectricBall()],
+      [PowerUpType.PARTY_FAVOR, () => this.applyPartyFavor()],
     ]);
 
     // Initialize effect propagation config
@@ -416,6 +417,18 @@ export class PowerUpSystem {
    */
   getFireballLevel(): number {
     return this.fireballLevel;
+  }
+
+  /**
+   * Apply Party Favor effect (extra life)
+   * Instant effect - emits event for GameScene to handle lives
+   */
+  private applyPartyFavor(): void {
+    // Emit event for GameScene to grant extra life
+    this.events.emit('grantExtraLife');
+
+    // No duration tracking - instant effect
+    this.events.emit('effectApplied', PowerUpType.PARTY_FAVOR);
   }
 
   /**

--- a/src/types/PowerUpTypes.ts
+++ b/src/types/PowerUpTypes.ts
@@ -10,6 +10,7 @@ export enum PowerUpType {
   POWERBALL = 'powerball', // Double power-up drop chance (12s)
   FIREBALL = 'fireball', // Piercing ball with stacking damage (10s)
   ELECTRICBALL = 'electricball', // Electric ball with AOE damage (8s)
+  PARTY_FAVOR = 'partyfavor', // Extra life (instant, very rare)
 }
 
 /**
@@ -82,6 +83,13 @@ export const POWERUP_CONFIGS: Record<PowerUpType, PowerUpConfig> = {
     duration: 8000,       // 8 seconds
     dropWeight: 12,
     emoji: '⚡',
+  },
+  [PowerUpType.PARTY_FAVOR]: {
+    type: PowerUpType.PARTY_FAVOR,
+    color: 0xff69b4,      // Hot pink
+    duration: 0,          // Instant effect
+    dropWeight: 3,        // Very rare
+    emoji: '🎁',
   },
 };
 


### PR DESCRIPTION
## 🎁 Party Favor (Extra Life)

Adds a new rare power-up that grants +1 life. Rebased on master per Scott's request so CI runs on it.

### Implementation
- **Type**: `PARTY_FAVOR` / `partyfavor`
- **Color**: Hot pink (0xff69b4)
- **Duration**: Instant
- **Drop Weight**: 3 (very rare — compare to Balloon at 20)
- **Emoji**: 🎁

### How it works
- PowerUpSystem emits `grantExtraLife` event
- GameScene listens and increments `lives`
- UI updates via existing `livesUpdate` event

### Visual feedback
- Display text: "EXTRA LIFE!"
- Golden screen flash (200ms)
- Pink/gold particle burst (20 particles)

Also includes test fix for `powerUpDropChance` removal (same as PR #28).

### Test Instructions
```
GameDebug.spawnPowerUp('partyfavor', 400, 300)
```
- Verify life count increases
- Verify UI updates
- Verify particles/flash feedback
- `npm test` — 131 tests pass
- `npm run build` — clean

Closes #30