### PR TITLE
test: Paddle collision angle calculation

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -387,6 +387,7 @@ All SFX are **synthesized at runtime** via Web Audio API (no audio files):
 | **Currency Conversion** | `CurrencyManager.calculateCurrencyFromScore()` returns correct values across all tier thresholds (0, 100, 1K, 5K, 10K, 25K scores) |
 | **Brick Drop Chances** | Every `BrickType` has a `BRICK_DROP_CHANCES` entry between 0–1, with correct ordering (Present < Piñata < Balloon) |
 | **Constants Validation** | All game constants in `config/Constants.ts` have sane values: positive dimensions, valid ranges (0–1 for volumes/probabilities), ascending tier thresholds, valid hex colors, positive scores/durations |
+| **Paddle Collision** | Center/edge/clamped angle calculations return correct radian values |
 
 ### Commands
 ```bash

--- a/src/__tests__/paddleCollision.test.ts
+++ b/src/__tests__/paddleCollision.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { calculatePaddleBounceAngle } from '../utils/paddleAngle';
+
+describe('Paddle Collision Angle Calculation', () => {
+  const paddleX = 400;
+  const paddleHalfWidth = 60;
+
+  const degToRad = (deg: number) => deg * (Math.PI / 180);
+
+  it('returns -90° (straight up) for center hit', () => {
+    const angle = calculatePaddleBounceAngle(paddleX, paddleX, paddleHalfWidth);
+    expect(angle).toBeCloseTo(degToRad(-90), 4);
+  });
+
+  it('returns -150° for exact left edge hit', () => {
+    const ballX = paddleX - paddleHalfWidth;
+    const angle = calculatePaddleBounceAngle(ballX, paddleX, paddleHalfWidth);
+    expect(angle).toBeCloseTo(degToRad(-150), 4);
+  });
+
+  it('returns -30° for exact right edge hit', () => {
+    const ballX = paddleX + paddleHalfWidth;
+    const angle = calculatePaddleBounceAngle(ballX, paddleX, paddleHalfWidth);
+    expect(angle).toBeCloseTo(degToRad(-30), 4);
+  });
+
+  it('clamps to -150° when hit is beyond left edge', () => {
+    const ballX = paddleX - paddleHalfWidth - 50;
+    const angle = calculatePaddleBounceAngle(ballX, paddleX, paddleHalfWidth);
+    expect(angle).toBeCloseTo(degToRad(-150), 4);
+  });
+
+  it('clamps to -30° when hit is beyond right edge', () => {
+    const ballX = paddleX + paddleHalfWidth + 50;
+    const angle = calculatePaddleBounceAngle(ballX, paddleX, paddleHalfWidth);
+    expect(angle).toBeCloseTo(degToRad(-30), 4);
+  });
+
+  it('returns -120° for quarter-left position', () => {
+    const ballX = paddleX - paddleHalfWidth / 2;
+    const angle = calculatePaddleBounceAngle(ballX, paddleX, paddleHalfWidth);
+    expect(angle).toBeCloseTo(degToRad(-120), 4);
+  });
+
+  it('returns -60° for quarter-right position', () => {
+    const ballX = paddleX + paddleHalfWidth / 2;
+    const angle = calculatePaddleBounceAngle(ballX, paddleX, paddleHalfWidth);
+    expect(angle).toBeCloseTo(degToRad(-60), 4);
+  });
+});

--- a/src/objects/Paddle.ts
+++ b/src/objects/Paddle.ts
@@ -1,5 +1,6 @@
 import Phaser from 'phaser';
 import { PADDLE_WIDTH, PADDLE_HEIGHT, PADDLE_Y_OFFSET, PADDLE_SPEED, GAME_WIDTH, PLAY_AREA_Y, PLAYABLE_HEIGHT } from '../config/Constants';
+import { calculatePaddleBounceAngle } from '../utils/paddleAngle';
 
 export class Paddle extends Phaser.Physics.Arcade.Sprite {
   private baseWidth: number = PADDLE_WIDTH;
@@ -65,23 +66,7 @@ export class Paddle extends Phaser.Physics.Arcade.Sprite {
    * Returns angle in radians (negative = upward)
    */
   getCollisionAngle(ballX: number): number {
-    const paddleCenter = this.x;
-    const paddleHalfWidth = this.currentWidth / 2;
-
-    // -1 to 1 based on hit position
-    const hitPosition = (ballX - paddleCenter) / paddleHalfWidth;
-
-    // Clamp hit position
-    const clampedHit = Phaser.Math.Clamp(hitPosition, -1, 1);
-
-    // Map to angle range: -150 to -30 degrees (upward arc)
-    // Center = -90 (straight up), edges = steeper angles
-    const minAngle = -150; // Left edge
-    const maxAngle = -30;  // Right edge
-
-    const angleDeg = Phaser.Math.Linear(minAngle, maxAngle, (clampedHit + 1) / 2);
-
-    return Phaser.Math.DegToRad(angleDeg);
+    return calculatePaddleBounceAngle(ballX, this.x, this.currentWidth / 2);
   }
 
   /**

--- a/src/utils/paddleAngle.ts
+++ b/src/utils/paddleAngle.ts
@@ -1,0 +1,27 @@
+/**
+ * Calculate the bounce angle for a ball hitting a paddle.
+ * @param ballX - X position where the ball hits
+ * @param paddleX - X position of paddle center
+ * @param paddleHalfWidth - Half the paddle width
+ * @returns Angle in radians (negative = upward)
+ */
+export function calculatePaddleBounceAngle(
+  ballX: number,
+  paddleX: number,
+  paddleHalfWidth: number
+): number {
+  const hitPosition = (ballX - paddleX) / paddleHalfWidth;
+  
+  // Clamp hit position to [-1, 1]
+  const clampedHit = Math.max(-1, Math.min(1, hitPosition));
+  
+  const minAngle = -150; // degrees
+  const maxAngle = -30;  // degrees
+  
+  // Linear interpolation: minAngle + (maxAngle - minAngle) * t
+  const t = (clampedHit + 1) / 2;
+  const angleDeg = minAngle + (maxAngle - minAngle) * t;
+  
+  // Convert degrees to radians
+  return angleDeg * (Math.PI / 180);
+}


### PR DESCRIPTION
Closes #41

## Summary
Adds unit tests for paddle collision angle calculation by extracting the logic into a testable utility function.

## Changes
- Created `src/utils/paddleAngle.ts` with pure `calculatePaddleBounceAngle()` function
- Updated `Paddle.getCollisionAngle()` to use the utility
- Added test suite with 7 test cases covering center, edges, clamping, and interpolation
- Updated FEATURES.md with new test coverage entry

## Test Instructions
```bash
npm test
```
All paddle collision tests should pass.