### PR TITLE
test: Weighted random power-up selection (#42)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -397,7 +397,18 @@ npm run test:watch # Run tests in watch mode (development)
 
 ---
 
-## 9. TODO / Known Gaps
+## 9. Utilities
+
+### Weighted Random Selection
+- **`src/utils/weightedSelection.ts`** — Pure, testable utility for weighted random selection
+- `weightedSelect<T>(items, randomValue)` — Selects item based on weights and a provided random value (0-1)
+- `getTotalWeight<T>(items)` — Convenience helper to sum item weights
+- **Power-up selection** uses this utility with weights from `POWERUP_CONFIGS`
+- Supports edge cases: zero weights, negative weights (treated as zero), empty arrays
+
+---
+
+## 10. TODO / Known Gaps
 
 ### Unused Systems
 - **Currency system exists but has no shop**: `CurrencyManager` has `spendCurrency()`, `canAfford()`, and `resetCurrency()` methods, but there is no shop scene or purchasable items. Coins accumulate with no way to spend them.

--- a/src/__tests__/weightedSelection.test.ts
+++ b/src/__tests__/weightedSelection.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { weightedSelect, getTotalWeight, WeightedItem } from '../../src/utils/weightedSelection';
+import { POWERUP_CONFIGS, PowerUpType, getTotalDropWeight } from '../../src/types/PowerUpTypes';
+
+describe('weightedSelect', () => {
+  describe('basic functionality', () => {
+    const items: WeightedItem<string>[] = [
+      { value: 'A', weight: 10 },
+      { value: 'B', weight: 20 },
+      { value: 'C', weight: 30 },
+    ];
+    // Total weight = 60, so:
+    // A: 0-10 (0.0 - 0.167)
+    // B: 10-30 (0.167 - 0.5)
+    // C: 30-60 (0.5 - 1.0)
+
+    it('selects first item when random is 0', () => {
+      expect(weightedSelect(items, 0)).toBe('A');
+    });
+
+    it('selects first item at upper boundary', () => {
+      // Just under 10/60 = 0.1666...
+      expect(weightedSelect(items, 0.16)).toBe('A');
+    });
+
+    it('selects second item after first boundary', () => {
+      expect(weightedSelect(items, 0.17)).toBe('B');
+    });
+
+    it('selects second item at middle', () => {
+      expect(weightedSelect(items, 0.4)).toBe('B');
+    });
+
+    it('selects last item when random is close to 1', () => {
+      expect(weightedSelect(items, 0.99)).toBe('C');
+    });
+
+    it('selects last item at boundary', () => {
+      // At 0.5, threshold = 30. After A(10) → 20, after B(20) → 0, returns B
+      // Need 0.51 to cross into C territory
+      expect(weightedSelect(items, 0.51)).toBe('C');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles single item', () => {
+      const items: WeightedItem<string>[] = [{ value: 'only', weight: 100 }];
+      expect(weightedSelect(items, 0)).toBe('only');
+      expect(weightedSelect(items, 0.5)).toBe('only');
+      expect(weightedSelect(items, 0.99)).toBe('only');
+    });
+
+    it('handles equal weights', () => {
+      const items: WeightedItem<string>[] = [
+        { value: 'A', weight: 10 },
+        { value: 'B', weight: 10 },
+        { value: 'C', weight: 10 },
+      ];
+      expect(weightedSelect(items, 0)).toBe('A');
+      expect(weightedSelect(items, 0.34)).toBe('B');
+      expect(weightedSelect(items, 0.67)).toBe('C');
+    });
+
+    it('skips zero-weight items', () => {
+      const items: WeightedItem<string>[] = [
+        { value: 'zero', weight: 0 },
+        { value: 'positive', weight: 10 },
+      ];
+      // Only 'positive' should ever be selected
+      expect(weightedSelect(items, 0)).toBe('positive');
+      expect(weightedSelect(items, 0.99)).toBe('positive');
+    });
+
+    it('handles all zero weights', () => {
+      const items: WeightedItem<string>[] = [
+        { value: 'A', weight: 0 },
+        { value: 'B', weight: 0 },
+      ];
+      expect(weightedSelect(items, 0.5)).toBeNull();
+    });
+
+    it('handles empty array', () => {
+      expect(weightedSelect([], 0.5)).toBeNull();
+    });
+
+    it('handles negative weights as zero', () => {
+      const items: WeightedItem<string>[] = [
+        { value: 'negative', weight: -10 },
+        { value: 'positive', weight: 10 },
+      ];
+      expect(weightedSelect(items, 0)).toBe('positive');
+    });
+  });
+});
+
+describe('getTotalWeight', () => {
+  it('sums positive weights', () => {
+    const items: WeightedItem<string>[] = [
+      { value: 'A', weight: 10 },
+      { value: 'B', weight: 20 },
+    ];
+    expect(getTotalWeight(items)).toBe(30);
+  });
+
+  it('ignores negative weights', () => {
+    const items: WeightedItem<string>[] = [
+      { value: 'A', weight: -5 },
+      { value: 'B', weight: 10 },
+    ];
+    expect(getTotalWeight(items)).toBe(10);
+  });
+
+  it('returns 0 for empty array', () => {
+    expect(getTotalWeight([])).toBe(0);
+  });
+});
+
+describe('Power-up selection integration', () => {
+  it('POWERUP_CONFIGS weights sum to expected total', () => {
+    // Currently 107: balloon(20) + cake(15) + drinks(15) + disco(10) + mystery(10) + 
+    // powerball(12) + fireball(10) + electricball(12) + partyfavor(3)
+    expect(getTotalDropWeight()).toBe(107);
+  });
+
+  it('all power-up types have positive weights', () => {
+    for (const type of Object.values(PowerUpType)) {
+      const config = POWERUP_CONFIGS[type];
+      expect(config.dropWeight).toBeGreaterThan(0);
+    }
+  });
+
+  it('all power-up types are reachable via selection', () => {
+    // Create items from config
+    const items: WeightedItem<PowerUpType>[] = Object.values(POWERUP_CONFIGS).map(c => ({
+      value: c.type,
+      weight: c.dropWeight,
+    }));
+
+    // Each type should be selectable with the right random value
+    let cumulative = 0;
+    const total = getTotalDropWeight();
+
+    for (const config of Object.values(POWERUP_CONFIGS)) {
+      // Use a value in the middle of this item's range
+      const midpoint = (cumulative + config.dropWeight / 2) / total;
+      const selected = weightedSelect(items, midpoint);
+      expect(selected).toBe(config.type);
+      cumulative += config.dropWeight;
+    }
+  });
+});

--- a/src/types/PowerUpTypes.ts
+++ b/src/types/PowerUpTypes.ts
@@ -1,3 +1,5 @@
+import { weightedSelect, WeightedItem } from '../utils/weightedSelection';
+
 /**
  * Power-up types in Geno's Block Party
  */
@@ -94,9 +96,19 @@ export const POWERUP_CONFIGS: Record<PowerUpType, PowerUpConfig> = {
 };
 
 /**
- * Get total weight for probability calculation
+ * Get weighted items for power-up selection
  */
-function getTotalDropWeight(): number {
+function getPowerUpWeightedItems(): WeightedItem<PowerUpType>[] {
+  return Object.values(POWERUP_CONFIGS).map(config => ({
+    value: config.type,
+    weight: config.dropWeight,
+  }));
+}
+
+/**
+ * Get total weight for probability calculation (exported for testing)
+ */
+export function getTotalDropWeight(): number {
   return Object.values(POWERUP_CONFIGS).reduce((sum, config) => sum + config.dropWeight, 0);
 }
 
@@ -104,18 +116,8 @@ function getTotalDropWeight(): number {
  * Select a random power-up type based on weighted drop chances
  */
 export function selectRandomPowerUpType(): PowerUpType {
-  const totalWeight = getTotalDropWeight();
-  let random = Math.random() * totalWeight;
-
-  for (const config of Object.values(POWERUP_CONFIGS)) {
-    random -= config.dropWeight;
-    if (random <= 0) {
-      return config.type;
-    }
-  }
-
-  // Fallback
-  return PowerUpType.BALLOON;
+  const result = weightedSelect(getPowerUpWeightedItems(), Math.random());
+  return result ?? PowerUpType.BALLOON; // Fallback
 }
 
 /**

--- a/src/utils/weightedSelection.ts
+++ b/src/utils/weightedSelection.ts
@@ -1,0 +1,32 @@
+export interface WeightedItem<T> {
+  value: T;
+  weight: number;
+}
+
+/**
+ * Select item from weighted list using provided random value (0-1)
+ * @param items Array of items with weights
+ * @param randomValue Number between 0 and 1 (exclusive)
+ * @returns Selected item value, or null if no valid items
+ */
+export function weightedSelect<T>(items: WeightedItem<T>[], randomValue: number): T | null {
+  const totalWeight = items.reduce((sum, item) => sum + Math.max(0, item.weight), 0);
+  if (totalWeight <= 0) return null;
+
+  let threshold = randomValue * totalWeight;
+  for (const item of items) {
+    if (item.weight <= 0) continue;
+    threshold -= item.weight;
+    if (threshold <= 0) {
+      return item.value;
+    }
+  }
+  return items[items.length - 1]?.value ?? null;
+}
+
+/**
+ * Get total weight of all items (convenience helper)
+ */
+export function getTotalWeight<T>(items: WeightedItem<T>[]): number {
+  return items.reduce((sum, item) => sum + Math.max(0, item.weight), 0);
+}


### PR DESCRIPTION
Adds unit tests for the weighted random selection system used by power-ups.

## Changes
- New `src/utils/weightedSelection.ts` utility with pure, testable functions
- Refactored `selectRandomPowerUpType()` to use the new utility
- Comprehensive test suite covering:
  - Basic weighted selection
  - Edge cases (zero weight, single item, equal weights, negative weights)
  - Integration tests with actual power-up configs
- Updated FEATURES.md with new Utilities section

## Test Instructions
```bash
npm run test
```

Closes #42