### PR TITLE
fix: bumper sprite scales to full screen on hit (#85)

### DIFF
--- a/src/objects/Bumper.ts
+++ b/src/objects/Bumper.ts
@@ -70,11 +70,13 @@ export class Bumper extends Phaser.Physics.Arcade.Sprite {
     // Flash to white
     this.setTint(COLORS.BUMPER_FLASH);
 
-    // Scale punch for impact feel
+    // Scale punch for impact feel (relative to display scale, not texture scale)
+    const baseScaleX = this.scaleX;
+    const baseScaleY = this.scaleY;
     this.scene.tweens.add({
       targets: this,
-      scaleX: 1.15,
-      scaleY: 1.15,
+      scaleX: baseScaleX * 1.15,
+      scaleY: baseScaleY * 1.15,
       duration: this.flashDuration / 2,
       yoyo: true,
       ease: 'Quad.easeOut',


### PR DESCRIPTION
Closes #85

## Changes
- Fixed bumper hit animation that caused sprite to blow up to full screen
- The tween was setting scaleX/scaleY to absolute 1.15, but setDisplaySize(40,40) on a 320x320 texture means the base scale is ~0.125 — so 1.15 made it 9x too large
- Now tweens relative to the current display scale (baseScale * 1.15)

## Test Instructions
1. Start a level with bumpers
2. Hit a bumper with the ball
3. Verify the bumper flashes/animates without scaling to full screen