### PR TITLE
fix: correct safety net sprite positioning (#84)

### DIFF
--- a/src/objects/SafetyNet.ts
+++ b/src/objects/SafetyNet.ts
@@ -32,6 +32,10 @@ export class SafetyNet extends Phaser.Physics.Arcade.Sprite {
     // Scale HD sprite to game dimensions (800×10)
     this.setDisplaySize(PLAYABLE_WIDTH, 10);
 
+    // Capture computed scales so spawn animation preserves display size
+    const targetScaleX = this.scaleX;
+    const targetScaleY = this.scaleY;
+
     // Semi-transparent glowing green bar
     this.setAlpha(0.7);
     this.setDepth(5);
@@ -46,11 +50,11 @@ export class SafetyNet extends Phaser.Physics.Arcade.Sprite {
       ease: 'Sine.easeInOut',
     });
 
-    // Spawn animation: scale in vertically
-    this.setScale(1, 0);
+    // Spawn animation: scale in vertically (from 0 to target, preserving display size)
+    this.setScale(targetScaleX, 0);
     scene.tweens.add({
       targets: this,
-      scaleY: 1,
+      scaleY: targetScaleY,
       duration: 300,
       ease: 'Back.easeOut',
     });
@@ -84,12 +88,12 @@ export class SafetyNet extends Phaser.Physics.Arcade.Sprite {
     particles.explode();
     this.scene.time.delayedCall(500, () => particles.destroy());
 
-    // Scale up and fade out
+    // Scale up and fade out (multiply current scales for proportional burst)
     this.scene.tweens.add({
       targets: this,
       alpha: 0,
-      scaleY: 3,
-      scaleX: 1.3,
+      scaleY: this.scaleY * 3,
+      scaleX: this.scaleX * 1.3,
       duration: 300,
       ease: 'Quad.easeOut',
       onComplete: () => {


### PR DESCRIPTION
Closes #84

## Changes
- Fixed safety net spawn animation overriding `setDisplaySize` scales — was causing the net to render at full texture size (1408×768) instead of 800×10
- Destroy animation now also uses proportional scales instead of absolute values
- Safety net correctly renders below paddle (Y=1025) and above death zone (Y=1050)

## Test Instructions
1. Start the game, activate Bounce House power-up
2. Verify safety net appears as a thin bar BELOW the paddle
3. Verify it catches the ball correctly
4. Verify destroy animation looks proportional