### PR TITLE
fix: set power-up display size to 24x24 (#82)

### DIFF
--- a/src/config/Constants.ts
+++ b/src/config/Constants.ts
@@ -52,6 +52,7 @@ export const BRICK_COLS = 10;
 export const STARTING_LIVES = 3;
 export const POWERUP_DROP_CHANCE = 0.25;
 export const POWERUP_FALL_SPEED = 150;
+export const POWERUP_DISPLAY_SIZE = 24;
 
 // Colors (hex)
 // Note: Power-up colors are defined in POWERUP_CONFIGS (src/types/PowerUpTypes.ts)

--- a/src/objects/PowerUp.ts
+++ b/src/objects/PowerUp.ts
@@ -1,6 +1,6 @@
 import Phaser from 'phaser';
 import { PowerUpType } from '../types/PowerUpTypes';
-import { POWERUP_FALL_SPEED, GAME_HEIGHT } from '../config/Constants';
+import { POWERUP_FALL_SPEED, POWERUP_DISPLAY_SIZE, GAME_HEIGHT } from '../config/Constants';
 
 export class PowerUp extends Phaser.Physics.Arcade.Sprite {
   private powerUpType: PowerUpType;
@@ -16,8 +16,13 @@ export class PowerUp extends Phaser.Physics.Arcade.Sprite {
     scene.add.existing(this);
     scene.physics.add.existing(this);
 
+    // Scale down HD texture (192×192) to game size
+    this.setDisplaySize(POWERUP_DISPLAY_SIZE, POWERUP_DISPLAY_SIZE);
+
     // Configure physics body
     const body = this.body as Phaser.Physics.Arcade.Body;
+    body.setSize(POWERUP_DISPLAY_SIZE, POWERUP_DISPLAY_SIZE);
+    body.setOffset((this.width - POWERUP_DISPLAY_SIZE) / 2, (this.height - POWERUP_DISPLAY_SIZE) / 2);
     body.setAllowGravity(false);
     body.setVelocityY(POWERUP_FALL_SPEED);
 
@@ -96,6 +101,9 @@ export class PowerUp extends Phaser.Physics.Arcade.Sprite {
     const body = this.body as Phaser.Physics.Arcade.Body;
     body.enable = true;  // Explicitly enable before reset
     body.reset(x, y);
+    this.setDisplaySize(POWERUP_DISPLAY_SIZE, POWERUP_DISPLAY_SIZE);
+    body.setSize(POWERUP_DISPLAY_SIZE, POWERUP_DISPLAY_SIZE);
+    body.setOffset((this.width - POWERUP_DISPLAY_SIZE) / 2, (this.height - POWERUP_DISPLAY_SIZE) / 2);
     body.setAllowGravity(false);
     body.setVelocityY(POWERUP_FALL_SPEED);
 


### PR DESCRIPTION
Closes #82

## Changes
- Added `POWERUP_DISPLAY_SIZE = 24` constant in Constants.ts
- Added setDisplaySize(24, 24) to PowerUp constructor and activate() method
- Fixed physics body size and offset to match 24x24 display size
- Power-ups now render at correct game dimensions instead of full HD texture size

## Test Instructions
1. Play any level and trigger a power-up drop
2. Power-ups should be small icons (24x24) not giant sprites
3. Collision with paddle should feel correct (not triggering from far away)