### PR TITLE
fix: power-up sprite sizing and pulse animation (#82)

### DIFF
--- a/src/objects/PowerUp.ts
+++ b/src/objects/PowerUp.ts
@@ -36,10 +36,12 @@ export class PowerUp extends Phaser.Physics.Arcade.Sprite {
       ease: 'Sine.easeInOut',
     });
 
-    // Add pulsing glow effect
+    // Add pulsing glow effect (use scaled values, not absolute)
+    const baseScale = this.scaleX;  // After setDisplaySize, this is ~0.125 for 192→24
     scene.tweens.add({
       targets: this,
-      scale: 1.2,
+      scaleX: baseScale * 1.2,
+      scaleY: baseScale * 1.2,
       duration: 400,
       yoyo: true,
       repeat: -1,
@@ -95,7 +97,6 @@ export class PowerUp extends Phaser.Physics.Arcade.Sprite {
     this.setPosition(x, y);
     this.setActive(true);
     this.setVisible(true);
-    this.setScale(1);
     this.setAlpha(1);  // Reset alpha (was set to 0 during collect animation)
 
     const body = this.body as Phaser.Physics.Arcade.Body;
@@ -118,9 +119,11 @@ export class PowerUp extends Phaser.Physics.Arcade.Sprite {
       ease: 'Sine.easeInOut',
     });
 
+    const baseScale = this.scaleX;  // After setDisplaySize, this is ~0.125 for 192→24
     this.scene.tweens.add({
       targets: this,
-      scale: 1.2,
+      scaleX: baseScale * 1.2,
+      scaleY: baseScale * 1.2,
       duration: 400,
       yoyo: true,
       repeat: -1,
@@ -134,9 +137,11 @@ export class PowerUp extends Phaser.Physics.Arcade.Sprite {
   playCollectAnimation(onComplete?: () => void): void {
     this.scene.tweens.killTweensOf(this);
 
+    const collectScale = this.scaleX * 2;  // Double current display scale, not absolute
     this.scene.tweens.add({
       targets: this,
-      scale: 2,
+      scaleX: collectScale,
+      scaleY: collectScale,
       alpha: 0,
       duration: 200,
       ease: 'Quad.easeOut',

--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -413,7 +413,7 @@ export class UIScene extends Phaser.Scene {
 
     // Power-up icon
     const icon = this.add.image(0, 0, `powerup-${type}`);
-    icon.setScale(1.5);
+    icon.setDisplaySize(28, 28);  // Slightly larger than game size for UI visibility
     container.add(icon);
 
     // Timer bar (if duration provided)


### PR DESCRIPTION
Closes #82

## Changes
- Fixed power-up pulse tween to use relative scale values (baseScale * 1.2) instead of absolute scale (1.2), preventing HD textures from rendering at native 192px size
- Fixed collect animation to scale relative to display size
- Fixed UI power-up indicator icons to use setDisplaySize(28, 28) instead of setScale(1.5)
- Removed erroneous setScale(1) in activate() that was resetting display size

## Root Cause
Power-up textures are 192×192 HD but displayed at 24×24. Phaser tweens on `scale` used absolute values (e.g., 1.2), which meant the sprite pulsed between ~0.125 (24px) and 1.2 (230px). The fix ensures all scale tweens use the post-setDisplaySize scale as their base.

## Test Instructions
1. Play any level with power-ups
2. Verify power-ups fall at correct ~24x24 size
3. Verify pulse animation stays subtle (not growing to full HD size)
4. Collect a power-up — verify UI icon is correct size
5. Check collision feels right (not triggering from far away)