### PR TITLE
feat: update item shop to show sprite asset previews (#96)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -606,6 +606,8 @@ Achievement-based milestones that unlock exclusive cosmetic rewards:
 
 - Milestones are checked at game end
 - Achievement celebration overlay shows when milestones are unlocked
+- Paddle skin previews display the actual pixel art sprite assets
+- Ball trail previews show the ball sprite with colored trail particle dots
 - Milestone rewards appear in Party Shop with "🔒 [Milestone Name]" until unlocked
 - Once unlocked, milestone items show "✓ Unlocked" and can be equipped for free
 - Progress is saved in localStorage under `genos-block-party-milestones`

--- a/src/scenes/ShopScene.ts
+++ b/src/scenes/ShopScene.ts
@@ -15,7 +15,6 @@ import { ITEM_TO_MILESTONE, MILESTONES } from '../systems/MilestoneSystem';
 import {
   ShopCategory,
   type ShopItem,
-  type PaddleSkinConfig,
   type BallTrailConfig,
   PADDLE_SKINS,
   BALL_TRAILS,
@@ -220,27 +219,15 @@ export class ShopScene extends Phaser.Scene {
 
     // Preview visual
     if (item.category === ShopCategory.PADDLE_SKIN) {
-      const skin = item as PaddleSkinConfig;
-      const previewW = 80;
-      const previewH = 14;
-      const previewAlpha = skin.alpha ?? 1;
-
-      const preview = this.add.rectangle(x, y - 35, previewW, previewH, skin.color, previewAlpha);
-      preview.setStrokeStyle(1, 0xffffff, 0.3);
+      // Use the actual paddle skin sprite asset
+      const preview = this.add.image(x, y - 35, 'paddle-skin-' + item.id);
+      preview.setDisplaySize(80, 20);
       this.itemContainer.add(preview);
-
-      // Accent dots
-      const leftDot = this.add.circle(x - 25, y - 35, 4, skin.accentColor, previewAlpha);
-      const rightDot = this.add.circle(x + 25, y - 35, 4, skin.accentColor, previewAlpha);
-      this.itemContainer.add(leftDot);
-      this.itemContainer.add(rightDot);
     } else {
-      // Ball trail preview — colored circles
+      // Ball trail preview — ball sprite with trail color dots
       const trail = item as BallTrailConfig;
       if (trail.colors.length > 0) {
-        const ballPreview = this.add.circle(x, y - 35, 8, 0xffffff);
-        this.itemContainer.add(ballPreview);
-        // Trail dots behind
+        // Trail dots behind the ball
         for (let i = 0; i < Math.min(trail.colors.length, 4); i++) {
           const dot = this.add.circle(
             x - 14 - i * 10,
@@ -251,9 +238,15 @@ export class ShopScene extends Phaser.Scene {
           );
           this.itemContainer.add(dot);
         }
+        // Ball sprite in front
+        const ballPreview = this.add.image(x, y - 35, 'ball');
+        ballPreview.setDisplaySize(16, 16);
+        this.itemContainer.add(ballPreview);
       } else {
-        // Default "none" — just show a ball
-        const ballPreview = this.add.circle(x, y - 35, 8, 0xffffff, 0.5);
+        // Default "none" — just show the ball sprite
+        const ballPreview = this.add.image(x, y - 35, 'ball');
+        ballPreview.setDisplaySize(16, 16);
+        ballPreview.setAlpha(0.5);
         this.itemContainer.add(ballPreview);
         const noText = this.add.text(x, y - 20, '(no trail)', {
           font: '10px Arial',


### PR DESCRIPTION
Closes #96

## Changes
- Paddle skin previews now show actual pixel art sprites instead of colored rectangles
- Ball preview uses the ball sprite asset instead of a plain circle
- Trail previews retain color particle dots for trail representation

## Test Instructions
1. Run the game and open the Party Shop
2. Switch between Paddles and Trails tabs
3. Verify paddle skins show their actual sprite art
4. Verify ball trails show the ball sprite with colored trail dots
5. Check that buy/equip buttons still work correctly