### PR TITLE
fix: rework spotlight to lock onto target brick (#101)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -181,7 +181,7 @@ Unlocked after completing the 10-level Story Mode campaign. Features infinite pr
 | **DJ Scratch** | 🧲 | 15s | 12 | Magnet paddle — ball sticks on contact, click to release |
 | **Confetti Cannon** | 🎊 | Instant | 10 | Fires confetti at 5-8 random bricks for 1 damage each |
 | **Conga Line** | 💃 | 8s | 8 | Trailing ghost balls deal damage to bricks |
-| **Spotlight** | 🔦 | 8s | 8 | Gentle homing toward nearest brick |
+| **Spotlight** | 🔦 | 8s | 8 | Homing — locks onto target brick |
 | **Dance Floor** | 🪩 | Instant | 10 | Shuffles all bricks to random grid positions |
 
 ### Fireball Stacking
@@ -221,9 +221,10 @@ Unlocked after completing the 10-level Story Mode campaign. Features infinite pr
 - Timer refreshes if collected again while active
 
 ### Spotlight Details
-- Ball gently curves toward the nearest brick while the effect is active
-- **Steering algorithm**: On each frame, calculates angle to nearest brick and adjusts velocity by max ~2.8° per frame
-- Subtle homing — player still has control over general direction, but ball "drifts" toward bricks
+- Ball locks onto a target brick and continuously homes toward it until that brick is destroyed
+- **Target selection**: Picks nearest brick once, then steers toward it persistently — no frame-by-frame recalculation
+- **After destroying the target**: automatically picks the next nearest brick and continues homing
+- **Steering algorithm**: Max ~2.3° per frame (0.04 rad) for a large, smooth turning circle (~2.6s for full 360°)
 - **Visual effects**:
   - Golden glow and tint on ball (0xffd700)
   - Light cone/beam emanating from ball in its direction of travel

--- a/src/types/PowerUpTypes.ts
+++ b/src/types/PowerUpTypes.ts
@@ -19,7 +19,7 @@ export enum PowerUpType {
   PARTY_FAVOR = 'partyfavor', // Extra life (instant, very rare)
   CONFETTI_CANNON = 'confetticannon', // Fires confetti at 5-8 random bricks
   CONGA_LINE = 'congaline', // Trailing ghost balls deal damage (8s)
-  SPOTLIGHT = 'spotlight', // Gentle homing toward nearest brick (8s)
+  SPOTLIGHT = 'spotlight', // Homing — locks onto target brick (8s)
   DANCE_FLOOR = 'dancefloor', // Shuffle all bricks to random positions (instant)
 }
 


### PR DESCRIPTION
Closes #101

## Changes
- Spotlight now picks a target brick and continuously homes toward it instead of recalculating nearest brick every frame
- After destroying the target brick, it picks the next one and continues
- Large turning circle (~2.6s for full 360°) for smooth arcing trajectories
- Continues until power-up expires

## Test Instructions
1. Play any level with bricks
2. Collect a Spotlight (🔦) power-up
3. Observe the ball locks onto one brick and arcs toward it
4. When that brick is destroyed, ball should pick a new target
5. Should NOT oscillate side-to-side between bricks